### PR TITLE
map-region-select-box-for-smaller-screen

### DIFF
--- a/src/web/modules/custom/workbc_jobboard/css/workbc_jobboard.css
+++ b/src/web/modules/custom/workbc_jobboard/css/workbc_jobboard.css
@@ -248,3 +248,35 @@ div.ui-dialog[aria-describedby="webform-terms-of-service-terms_of_service--descr
   transform: translateX(8px);
 }
 /***** Webform request-tour-stop ends *******/
+/***** Map regional profiles starts *******/
+.desktop-hidden{display:none;}
+@media screen and (max-width: 679px) {
+  .region-map-select.mobile-regions{
+    display:block;
+    position: relative;
+    overflow: hidden;
+    display: inline-block;
+    margin-bottom:20px;
+  }
+  .region-map-select.mobile-regions select{
+    padding: 9px 25px 9px 10px;
+  }
+  .custom-select__icon {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 45px;
+    width: 40px;
+    padding: 0;
+    z-index: 2;
+    pointer-events: none;
+    background-repeat: no-repeat;
+    background-size: 100%;
+    background-color: #224076;
+    background-position-y: 50%;
+  }
+  .webform-submission-request-a-tour-stop-form option:checked{
+    background-color:#224076;
+  }
+}
+/***** Map regional profiles ends *******/

--- a/src/web/modules/custom/workbc_jobboard/js/workbc_jobboard.js
+++ b/src/web/modules/custom/workbc_jobboard/js/workbc_jobboard.js
@@ -17,7 +17,11 @@
             };
           }
         });
-        
+        $(".region-map-select select", context).once('jobboard').on("change", function(){
+          if($(this).val() != ""){
+            window.location.href=$(this).val();
+          }
+        });
       });
 
       $(window, context).once('jobboard').on('hashchange load jobboardlogin', function (e) {


### PR DESCRIPTION
Add the select box using the code below within the content. 

```
<div aria-required="true" class="custom-select region-map-select form-dropdown-wrap mobile-regions desktop-hidden"><select class="form-dropdown" name="Region Selector" title="Select a region"><option selected="selected" value="">Select a region</option><option target-region="Cariboo" value="/region-profile/cariboo">Cariboo</option><option target-region="Kootenay" value="/region-profile/kootenay">Kootenay</option><option target-region="Mainland / Southwest" value="/region-profile/mainlandsouthwest">Mainland / Southwest</option><option target-region="North Coast &amp; Nechako" value="/region-profile/north-coast-and-nechako">North Coast &amp; Nechako</option><option target-region="Northeast" value="/region-profile/northeast">Northeast</option><option target-region="Thompson-Okanagan" value="/region-profile/thompson-okanagan">Thompson-Okanagan</option><option target-region="Vancouver Island / Coast" value="/region-profile/vancouver-islandcoast">Vancouver Island / Coast</option> </select> <svg class="custom-select__icon" height="320" id="Layer_1" viewbox="0 0 320 320" width="320" xmlns="http://www.w3.org/2000/svg">
<style type="text/css">.st0{fill:transparent;} .st1{fill:#ffffff;}
</style><path class="st0" d="M320 0v320H0V0h320z"></path><path class="st1" d="M202 136l-44 48-40-48h84z"></path></svg></div>
```

CSS is used for styling and showing, and hiding the select box, while JS opens the desired URL, which is manageable by content. 