### PR TITLE
Upgrade block_visibility_conditions and update the block configs

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -63,7 +63,7 @@
         "drupal/backup_migrate": "^5.0",
         "drupal/backup_migrate_aws_s3": "^5.0",
         "drupal/better_social_sharing_buttons": "^4.0",
-        "drupal/block_visibility_conditions": "^1.0",
+        "drupal/block_visibility_conditions": "1.x-dev#89c578b252af0d99c832af5b6c6ee4d52b6490d1",
         "drupal/bootstrap5": "^1.1",
         "drupal/cancel_button": "^1.3",
         "drupal/captcha": "^1.4",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c643bcf97fad491ee75d6c67163137f",
+    "content-hash": "d23d6bf49139f8cb72e721c05da977b2",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2724,29 +2724,26 @@
         },
         {
             "name": "drupal/block_visibility_conditions",
-            "version": "1.0.0",
+            "version": "dev-1.x",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/block_visibility_conditions.git",
-                "reference": "8.x-1.0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/block_visibility_conditions-8.x-1.0.zip",
-                "reference": "8.x-1.0",
-                "shasum": "cc3ca7940f23c13a05beb344ce1084778c6890c4"
+                "reference": "89c578b252af0d99c832af5b6c6ee4d52b6490d1"
             },
             "require": {
-                "drupal/core": "^8 || ^9"
+                "drupal/core": "^8 || ^9 || ^10"
             },
             "require-dev": {
                 "drupal/commerce_product": "*"
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
-                    "version": "8.x-1.0",
-                    "datestamp": "1587513847",
+                    "version": "8.x-1.x-dev",
+                    "datestamp": "1673037697",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -17766,6 +17763,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "drupal/block_visibility_conditions": 20,
         "drupal/linkit": 10
     },
     "prefer-stable": true,

--- a/src/config/sync/block.block.bettersocialsharingbuttons.yml
+++ b/src/config/sync/block.block.bettersocialsharingbuttons.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   module:
     - better_social_sharing_buttons
-    - block_visibility_conditions
     - system
   theme:
     - workbc
@@ -39,14 +38,6 @@ settings:
   width: 35px
   radius: 3px
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: true

--- a/src/config/sync/block.block.breadcrumbs.yml
+++ b/src/config/sync/block.block.breadcrumbs.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - system
   theme:
     - workbc
@@ -19,14 +18,6 @@ settings:
   label_display: '0'
   provider: system
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: true

--- a/src/config/sync/block.block.collectionnoticeblock.yml
+++ b/src/config/sync/block.block.collectionnoticeblock.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - system
     - workbc_custom
   theme:
@@ -20,14 +19,6 @@ settings:
   label_display: '0'
   provider: workbc_custom
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.contact_us_french_link.yml
+++ b/src/config/sync/block.block.contact_us_french_link.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - simple_block.simple_block.contact_us_french_link
   module:
-    - block_visibility_conditions
     - simple_block
     - system
   theme:
@@ -22,14 +21,6 @@ settings:
   label_display: '0'
   provider: simple_block
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.copyrightnotice.yml
+++ b/src/config/sync/block.block.copyrightnotice.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - simple_block.simple_block.copyright_notice
   module:
-    - block_visibility_conditions
     - simple_block
   theme:
     - workbc
@@ -20,12 +19,4 @@ settings:
   label: 'Copyright Notice'
   label_display: '0'
   provider: simple_block
-visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
+visibility: {  }

--- a/src/config/sync/block.block.employment_services_french_link.yml
+++ b/src/config/sync/block.block.employment_services_french_link.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - simple_block.simple_block.employment_services_french_link
   module:
-    - block_visibility_conditions
     - simple_block
     - system
   theme:
@@ -22,14 +21,6 @@ settings:
   label_display: '0'
   provider: simple_block
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.exposedformsearch_site_contentpage_1_2.yml
+++ b/src/config/sync/block.block.exposedformsearch_site_contentpage_1_2.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - views.view.search_site_content
   module:
-    - block_visibility_conditions
     - views
   theme:
     - workbc
@@ -21,12 +20,4 @@ settings:
   label_display: '0'
   provider: views
   views_label: ''
-visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
+visibility: {  }

--- a/src/config/sync/block.block.gtranslate.yml
+++ b/src/config/sync/block.block.gtranslate.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - gtranslate
   theme:
     - workbc
@@ -18,12 +17,4 @@ settings:
   label: Gtranslate
   label_display: visible
   provider: gtranslate
-visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
+visibility: {  }

--- a/src/config/sync/block.block.online_employment_services_french_link.yml
+++ b/src/config/sync/block.block.online_employment_services_french_link.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - simple_block.simple_block.online_employment_services_french_link
   module:
-    - block_visibility_conditions
     - simple_block
     - system
   theme:
@@ -22,14 +21,6 @@ settings:
   label_display: '0'
   provider: simple_block
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.onlinechat.yml
+++ b/src/config/sync/block.block.onlinechat.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - simple_block.simple_block.online_chat
   module:
-    - block_visibility_conditions
     - simple_block
     - system
   theme:
@@ -22,14 +21,6 @@ settings:
   label_display: '0'
   provider: simple_block
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.recentjobs.yml
+++ b/src/config/sync/block.block.recentjobs.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - node
     - workbc_jobboard
   theme:
@@ -24,14 +23,6 @@ settings:
   job_board_no_result_text: 'There are no current job postings.'
   job_board_results_to_show_horizontal_view: '4'
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   'entity_bundle:node':
     id: 'entity_bundle:node'
     negate: false

--- a/src/config/sync/block.block.related_topics.yml
+++ b/src/config/sync/block.block.related_topics.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - workbc_custom
   theme:
     - workbc
@@ -19,12 +18,4 @@ settings:
   label_display: '0'
   provider: workbc_custom
   trimmed_limit: '150'
-visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
+visibility: {  }

--- a/src/config/sync/block.block.responsivemenumobileicon.yml
+++ b/src/config/sync/block.block.responsivemenumobileicon.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - responsive_menu
   theme:
     - workbc
@@ -18,12 +17,4 @@ settings:
   label: 'Responsive menu mobile icon'
   label_display: '0'
   provider: responsive_menu
-visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
+visibility: {  }

--- a/src/config/sync/block.block.saveprofile.yml
+++ b/src/config/sync/block.block.saveprofile.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - node
     - workbc_jobboard
   theme:
@@ -20,14 +19,6 @@ settings:
   label_display: '0'
   provider: workbc_jobboard
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   'entity_bundle:node':
     id: 'entity_bundle:node'
     negate: false

--- a/src/config/sync/block.block.searchrecentjobs.yml
+++ b/src/config/sync/block.block.searchrecentjobs.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - workbc_jobboard
   theme:
     - workbc
@@ -24,12 +23,4 @@ settings:
   job_board_postjob_description: 'Use B.C.''s most comprehensive job board to post jobs for free and find the right people to help your business grow. With hundreds of thousands of job seekers using the site, it''s a great way to find new talent.'
   job_board_postjob_link_label: 'Post a Job'
   job_board_postjob_link_url: /access-employer-resources/hire-employees/find-workers
-visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
+visibility: {  }

--- a/src/config/sync/block.block.self_serve_services_french_link.yml
+++ b/src/config/sync/block.block.self_serve_services_french_link.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - simple_block.simple_block.self_serve_services_french_link
   module:
-    - block_visibility_conditions
     - simple_block
     - system
   theme:
@@ -22,14 +21,6 @@ settings:
   label_display: '0'
   provider: simple_block
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.sidenavblock.yml
+++ b/src/config/sync/block.block.sidenavblock.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - node
     - workbc_custom
   theme:
@@ -20,14 +19,6 @@ settings:
   label_display: '0'
   provider: workbc_custom
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   'entity_bundle:node':
     id: 'entity_bundle:node'
     negate: false

--- a/src/config/sync/block.block.socialnetworkinglinks.yml
+++ b/src/config/sync/block.block.socialnetworkinglinks.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - simple_block.simple_block.social_networking_links
   module:
-    - block_visibility_conditions
     - simple_block
   theme:
     - workbc
@@ -20,12 +19,4 @@ settings:
   label: 'Social Networking Links'
   label_display: '0'
   provider: simple_block
-visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
+visibility: {  }

--- a/src/config/sync/block.block.views_block__blog_block_1.yml
+++ b/src/config/sync/block.block.views_block__blog_block_1.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - views.view.blog
   module:
-    - block_visibility_conditions
     - system
     - views
   theme:
@@ -24,14 +23,6 @@ settings:
   views_label: ''
   items_per_page: none
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.views_block__industry_profiles_block_1.yml
+++ b/src/config/sync/block.block.views_block__industry_profiles_block_1.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - views.view.industry_profiles
   module:
-    - block_visibility_conditions
     - system
     - views
   theme:
@@ -24,14 +23,6 @@ settings:
   views_label: ''
   items_per_page: none
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.views_block__news_block_1.yml
+++ b/src/config/sync/block.block.views_block__news_block_1.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - views.view.news
   module:
-    - block_visibility_conditions
     - system
     - views
   theme:
@@ -24,14 +23,6 @@ settings:
   views_label: ''
   items_per_page: none
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.views_block__news_block_3.yml
+++ b/src/config/sync/block.block.views_block__news_block_3.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - views.view.news
   module:
-    - block_visibility_conditions
     - system
     - views
   theme:
@@ -24,14 +23,6 @@ settings:
   views_label: ''
   items_per_page: none
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.views_block__success_stories_block_1.yml
+++ b/src/config/sync/block.block.views_block__success_stories_block_1.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - views.view.success_stories
   module:
-    - block_visibility_conditions
     - system
     - views
   theme:
@@ -24,14 +23,6 @@ settings:
   views_label: ''
   items_per_page: none
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.views_block__video_library_block_1.yml
+++ b/src/config/sync/block.block.views_block__video_library_block_1.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - views.view.video_library
   module:
-    - block_visibility_conditions
     - system
     - views
   theme:
@@ -24,14 +23,6 @@ settings:
   views_label: ''
   items_per_page: none
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.visitaworkbccentre.yml
+++ b/src/config/sync/block.block.visitaworkbccentre.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - simple_block.simple_block.visit_a_workbc_centre
   module:
-    - block_visibility_conditions
     - simple_block
     - system
   theme:
@@ -22,14 +21,6 @@ settings:
   label_display: visible
   provider: simple_block
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.webform.yml
+++ b/src/config/sync/block.block.webform.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - webform.webform.workbc_order_form
   module:
-    - block_visibility_conditions
     - system
     - webform
   theme:
@@ -25,14 +24,6 @@ settings:
   default_data: ''
   redirect: false
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.webform_2.yml
+++ b/src/config/sync/block.block.webform_2.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - webform.webform.request_a_tour_stop
   module:
-    - block_visibility_conditions
     - system
     - webform
   theme:
@@ -25,14 +24,6 @@ settings:
   default_data: ''
   redirect: false
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.webform_3.yml
+++ b/src/config/sync/block.block.webform_3.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - webform.webform.contact
   module:
-    - block_visibility_conditions
     - system
     - webform
   theme:
@@ -25,14 +24,6 @@ settings:
   default_data: ''
   redirect: false
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.webform_4.yml
+++ b/src/config/sync/block.block.webform_4.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - webform.webform.funding_questionnaire
   module:
-    - block_visibility_conditions
     - system
     - webform
   theme:
@@ -25,14 +24,6 @@ settings:
   default_data: ''
   redirect: false
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.who_should_visit_workbc_centre_french_link.yml
+++ b/src/config/sync/block.block.who_should_visit_workbc_centre_french_link.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - simple_block.simple_block.who_should_visit_workbc_centre_french_link
   module:
-    - block_visibility_conditions
     - simple_block
     - system
   theme:
@@ -22,14 +21,6 @@ settings:
   label_display: '0'
   provider: simple_block
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.workbc_centre_locations_french_link.yml
+++ b/src/config/sync/block.block.workbc_centre_locations_french_link.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - simple_block.simple_block.workbc_centre_locations_french_link
   module:
-    - block_visibility_conditions
     - simple_block
     - system
   theme:
@@ -22,14 +21,6 @@ settings:
   label_display: '0'
   provider: simple_block
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.workbc_local_actions.yml
+++ b/src/config/sync/block.block.workbc_local_actions.yml
@@ -2,8 +2,6 @@ uuid: 91af30cc-1b84-4eed-a808-fe5111936547
 langcode: en
 status: true
 dependencies:
-  module:
-    - block_visibility_conditions
   theme:
     - workbc
 _core:
@@ -19,12 +17,4 @@ settings:
   label: 'Primary admin actions'
   label_display: '0'
   provider: core
-visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
+visibility: {  }

--- a/src/config/sync/block.block.workbc_local_tasks.yml
+++ b/src/config/sync/block.block.workbc_local_tasks.yml
@@ -2,8 +2,6 @@ uuid: e065a0c8-75c5-405f-9760-222beebcdd27
 langcode: en
 status: true
 dependencies:
-  module:
-    - block_visibility_conditions
   theme:
     - workbc
 _core:
@@ -21,12 +19,4 @@ settings:
   provider: core
   primary: true
   secondary: true
-visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
+visibility: {  }

--- a/src/config/sync/block.block.workbccareereventsblock.yml
+++ b/src/config/sync/block.block.workbccareereventsblock.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - system
     - workbc_custom
   theme:
@@ -20,14 +19,6 @@ settings:
   label_display: visible
   provider: workbc_custom
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.workbcexplorecareersblock.yml
+++ b/src/config/sync/block.block.workbcexplorecareersblock.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - system
     - workbc_custom
   theme:
@@ -30,14 +29,6 @@ settings:
   tooltip_1: 'The National Occupational Classification System (NOC) classifies all occupations in Canada.'
   path_2: /plan-career/explore-careers/career-search
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.workbchighopportunityoccupationsblock.yml
+++ b/src/config/sync/block.block.workbchighopportunityoccupationsblock.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - system
     - workbc_custom
   theme:
@@ -20,14 +19,6 @@ settings:
   label_display: '0'
   provider: workbc_custom
 visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
   request_path:
     id: request_path
     negate: false

--- a/src/config/sync/block.block.workbcmenublock.yml
+++ b/src/config/sync/block.block.workbcmenublock.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - block_visibility_conditions
     - workbc_menu
   theme:
     - workbc
@@ -18,12 +17,4 @@ settings:
   label: 'WorkBC menu block'
   label_display: '0'
   provider: workbc_menu
-visibility:
-  not_node_type:
-    id: not_node_type
-    bundles: {  }
-    negate: null
-  not_taxonomy_vocabulary:
-    id: not_taxonomy_vocabulary
-    bundles: {  }
-    negate: null
+visibility: {  }

--- a/src/config/sync/core.extension.yml
+++ b/src/config/sync/core.extension.yml
@@ -18,7 +18,6 @@ module:
   big_pipe: 0
   block: 0
   block_content: 0
-  block_visibility_conditions: 0
   breakpoint: 0
   calendar_listview: 0
   cancel_button: 0


### PR DESCRIPTION
The module `block_visibility_conditions` is not being used, and is reported as unsupported in the Drupal status report. 

It is not straighforward to remove it directly from the installation, because it leaves config entries in the site's blocks, which are deleted when we uninstall the module.

This PR solves this issue by:
- Upgrading the module to a version that allows being uninstalled without affecting the blocks
- Update the block configs to remove the module's unneeded entries
- Deactivate the module from the Drupal config to remove the warning related to the module

This PR does NOT remove the module code from the codebase, because doing so would prevent Drupal from deactivating it. The module code remains unused and inoffensive, but we can remove it from subsequent deployments.