### PR TITLE
[WR-1178] Job Board account menu

### DIFF
--- a/src/web/modules/custom/workbc_jobboard/js/workbc_jobboard.js
+++ b/src/web/modules/custom/workbc_jobboard/js/workbc_jobboard.js
@@ -128,11 +128,9 @@
         var CheckLogoutLinkMobileExists = $(".mobile-nav__user-nav .nav-items li.new-logout-link");
 
           if(currentUser != ''){
-            //
-            if(CheckLoginLinkExists.length < 1){
-              CheckLogoutLinkExists.remove();
-              CheckLogoutLinkMobileExists.remove();
-              var appendLoginMenusM = `
+            CheckLogoutLinkExists.remove();
+            CheckLogoutLinkMobileExists.remove();
+            var appendLoginMenusM = `
 <li class="nav-item new-login-link">
   <a href="/account#/dashboard" class="nav-link">My Profile</a>
 </li>
@@ -143,7 +141,7 @@
   <a href="/account#/logout" class="nav-link" onclick="localStorage.removeItem('currentUser'); document.cookie='currentUser.username=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/;'; document.cookie='currentUser.email=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/;'; document.cookie='currentUser.firstName=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/;'; document.cookie='currentUser.lastName=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/;'; document.cookie='currentUser.id=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/;'; document.cookie='currentUser.token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/;'; if (location.pathname === '/account') location.reload(true); else return true;">Log out</a>
 </li>
 `;
-              var appendLoginMenusD = `
+            var appendLoginMenusD = `
 <li class="nav-item new-login-link dropdown">
   <a  href="javascript:void(0)" class="nav-link dropdown-toggle" data-bs-toggle="dropdown">My Account</a>
   <ul class="dropdown-menu">
@@ -152,12 +150,13 @@
 </li>
 `;
 
-              //Desktop menu
-              $("nav.nav-user .nav-items").append(appendLoginMenusD);
+            //Desktop menu
+            CheckLoginLinkExists.remove();
+            $("nav.nav-user .nav-items").append(appendLoginMenusD);
 
-              //Mobile Menu
-              $(".mobile-nav__user-nav .nav-items").append(appendLoginMenusM);
-            }
+            //Mobile Menu
+            CheckLoginLinkMobileExists.remove();
+            $(".mobile-nav__user-nav .nav-items").append(appendLoginMenusM);
           }else{
             if(CheckLogoutLinkExists.length < 1){
               CheckLoginLinkExists.remove();

--- a/src/web/themes/custom/workbc/templates/navigation/menu--account--login.html.twig
+++ b/src/web/themes/custom/workbc/templates/navigation/menu--account--login.html.twig
@@ -1,0 +1,74 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+<ul{{ attributes.addClass(['nav-items']) }}>
+    {% else %}
+<ul>
+    {% endif %}
+    {% for item in items %}
+      {%
+        set classes_link = [
+        'nav-link',
+        item.is_expanded ? 'dropdown-toggle',
+        item.is_collapsed ? 'dropdown-toggle',
+        item.in_active_trail ? 'active',
+      ]
+      %}
+  <li{{ item.attributes.addClass('nav-item') }}>
+      {{ link(item.title, item.url, item.attributes.addClass(classes_link)) }}
+      {% if item.below %}
+        {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+      {% endif %}
+  </li>
+    {% endfor %}
+    {#
+      Manually add Job Board menu links.
+    #}
+    {% if menu_level == 0 %}
+<li class="nav-item new-login-link dropdown">
+  <a  href="javascript:void(0)" class="nav-link dropdown-toggle" data-bs-toggle="dropdown">My Account</a>
+  <ul class="dropdown-menu">
+    <li class="nav-item new-login-link">
+      <a href="/account#/dashboard" class="nav-link">My Profile</a>
+    </li>
+    <li class="nav-item new-login-link">
+      <a  href="/account#/personal-settings" class="nav-link">Personal Settings</a>
+    </li>
+    <li class="nav-item new-login-link">
+      <a href="/account#/logout" class="nav-link" onclick="localStorage.removeItem('currentUser'); document.cookie='currentUser.username=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/;'; document.cookie='currentUser.email=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/;'; document.cookie='currentUser.firstName=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/;'; document.cookie='currentUser.lastName=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/;'; document.cookie='currentUser.id=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/;'; document.cookie='currentUser.token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/;'; if (location.pathname === '/account') location.reload(true); else return true;">Log out</a>
+    </li>
+  </ul>
+</li>
+    {% endif %}
+</ul>
+  {% endif %}
+{% endmacro %}

--- a/src/web/themes/custom/workbc/templates/navigation/menu--account--logout.html.twig
+++ b/src/web/themes/custom/workbc/templates/navigation/menu--account--logout.html.twig
@@ -1,0 +1,66 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+<ul{{ attributes.addClass(['nav-items']) }}>
+    {% else %}
+<ul>
+    {% endif %}
+    {% for item in items %}
+      {%
+        set classes_link = [
+        'nav-link',
+        item.is_expanded ? 'dropdown-toggle',
+        item.is_collapsed ? 'dropdown-toggle',
+        item.in_active_trail ? 'active',
+      ]
+      %}
+  <li{{ item.attributes.addClass('nav-item') }}>
+      {{ link(item.title, item.url, item.attributes.addClass(classes_link)) }}
+      {% if item.below %}
+        {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+      {% endif %}
+  </li>
+    {% endfor %}
+    {#
+      Manually add Job Board menu links for logged out user.
+    #}
+    {% if menu_level == 0 %}
+<li class="nav-item new-logout-link">
+  <a href="/account#/login" class="nav-link">Log in</a>
+</li>
+<li class="nav-item new-logout-link">
+  <a href="/account#/register" class="nav-link">Register</a>
+</li>
+    {% endif %}
+</ul>
+  {% endif %}
+{% endmacro %}

--- a/src/web/themes/custom/workbc/workbc.theme
+++ b/src/web/themes/custom/workbc/workbc.theme
@@ -163,7 +163,7 @@ function workbc_preprocess_page(&$variables) {
 /**
  * Implements hook_theme_suggestions_menu_alter().
  *
- * Select an account menu template depending on whether a Job Board session.
+ * Select an account menu template depending on whether a Job Board session exists or not.
  * We inject the Job Board menu items dynamically because the Drupal menu is cached.
  */
 function workbc_theme_suggestions_menu_alter(array &$suggestions, array $variables) {

--- a/src/web/themes/custom/workbc/workbc.theme
+++ b/src/web/themes/custom/workbc/workbc.theme
@@ -9,7 +9,7 @@ use Drupal\file\Entity\File;
 use Drupal\Core\Url;
 
 /**
- * Implements hook theme_preprocess_paragraph().
+ * Implements hook_theme_preprocess_paragraph().
  */
 function workbc_preprocess_paragraph(&$variables) {
   $parent = $variables['paragraph']->getParentEntity();
@@ -114,7 +114,7 @@ function workbc_get_descendant($menu) {
 
 
 /**
- * Implements hook theme_suggestions_paragraph_alter().
+ * Implements hook_theme_suggestions_paragraph_alter().
  */
 function workbc_theme_suggestions_paragraph_alter(array &$suggestions, array $variables) {
 
@@ -143,7 +143,7 @@ function workbc_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_st
 }
 
 /**
- * Implements hook theme_preprocess_page().
+ * Implements hook_theme_preprocess_page().
  */
 function workbc_preprocess_page(&$variables) {
   // default page format
@@ -161,7 +161,24 @@ function workbc_preprocess_page(&$variables) {
 }
 
 /**
- * Implements hook theme_preprocess_node().
+ * Implements hook_theme_suggestions_menu_alter().
+ *
+ * Select an account menu template depending on whether a Job Board session.
+ * We inject the Job Board menu items dynamically because the Drupal menu is cached.
+ */
+function workbc_theme_suggestions_menu_alter(array &$suggestions, array $variables) {
+  if ($variables['menu_name'] === 'account') {
+    if (isset($_COOKIE['currentUser_token'])) {
+      $suggestions[] = 'menu__account__login';
+    }
+    else {
+      $suggestions[] = 'menu__account__logout';
+    }
+  }
+}
+
+/**
+ * Implements hook_theme_preprocess_node().
  */
 function workbc_preprocess_node(&$variables) {
   if ($variables['node']->bundle() === "publication" && $variables['view_mode'] === "publication") {
@@ -248,7 +265,7 @@ function workbc_preprocess_menu(&$vars) {
 
 
 /**
- * Implements hook theme_suggestions_paragraph_alter().
+ * Implements hook_theme_suggestions_paragraph_alter().
  */
 function workbc_theme_suggestions_form_element_alter(array &$suggestions, array $variables) {
   if (isset($variables['element']['#name'])) {
@@ -258,7 +275,7 @@ function workbc_theme_suggestions_form_element_alter(array &$suggestions, array 
 
 
 /**
- * Implements hook theme_preprocess_form_element().
+ * Implements hook_theme_preprocess_form_element().
  */
 function workbc_preprocess_form_element(&$variables) {
 


### PR DESCRIPTION
We dynamically inject Job Board menu items into the account menu, via JavaScript.
This causes a noticeable flicker in the menu.
This PR fixes the flicker by statically injecting the Job Board items via a theme template.
To make it dynamic, we override the theme suggestions via `hook_theme_suggestions_menu_alter` depending on the presence of the Job Board cookie `currentUser_token`.
