### PR TITLE
[WR-1538] do not load boilerplate mmenu css

### DIFF
--- a/src/config/sync/responsive_menu.settings.yml
+++ b/src/config/sync/responsive_menu.settings.yml
@@ -6,7 +6,7 @@ off_canvas_menus: main
 horizontal_wrapping_element: nav
 horizontal_breakpoint: xl-min
 horizontal_media_query: '(min-width: 1200px)'
-include_css: true
+include_css: false
 off_canvas_position: left
 off_canvas_theme: theme-white
 pagedim: pagedim-black


### PR DESCRIPTION
Change Drupal configuration using `drush config:export` so the mobile menu's (mmenu) boilerplate CSS file are not imported but instead rely on the customized one we wrote.  This change aligns with the guidance mmenu suggests on their configuration page.