### PR TITLE
WR-1715 Prevent content editor from selecting different Content Group

### DIFF
--- a/src/web/modules/custom/workbc_custom/workbc_custom.module
+++ b/src/web/modules/custom/workbc_custom/workbc_custom.module
@@ -157,6 +157,19 @@ function workbc_custom_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $
 }
 
 
+function workbc_custom_form_node_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+
+    $user = \Drupal\user\Entity\User::load(\Drupal::currentUser()->id());
+
+    if (isset($form['field_content_group']) && !$user->hasPermission('bypass content groups')) {
+      $form['field_content_group']['#access'] = false;
+      if (empty($form['field_content_group']['widget']['#default_value'])) {
+        $form['field_content_group']['widget']['#default_value'] = $user->get("field_content_group")->target_id;
+      }
+    }
+ 
+}
+
 
 function workbc_custom_form_views_exposed_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
 


### PR DESCRIPTION
hide Content Group for users who don't have permission to bypass content groups, set Content Group field value to User's content group when adding new content.