### PR TITLE
[WR-1509] Search index cleanup

### DIFF
--- a/src/config/sync/search_api.index.default_content_index.yml
+++ b/src/config/sync/search_api.index.default_content_index.yml
@@ -10,7 +10,6 @@ dependencies:
     - search_api_solr
     - node
     - search_api
-    - paragraphs
 third_party_settings:
   search_api_solr:
     finalize: false
@@ -98,10 +97,8 @@ field_settings:
           bc_profile: search_index
           blog: search_index
           career_profile: search_index
-          career_profile_introductions: ''
           event: search_index
           industry_profile: search_index
-          labour_market_monthly: search_index
           news: search_index
           page: search_index
           publication: search_index
@@ -146,14 +143,8 @@ datasource_settings:
         - industry_profile_introductions
         - labour_market_monthly
         - region_profile_introductions
+        - related_topics_card
         - resource
-    languages:
-      default: true
-      selected: {  }
-  'entity:paragraph':
-    bundles:
-      default: true
-      selected: {  }
     languages:
       default: true
       selected: {  }

--- a/src/web/modules/custom/workbc_extra_fields/src/Plugin/ExtraField/Display/CareerProfile/CareerProfileSkills.php
+++ b/src/web/modules/custom/workbc_extra_fields/src/Plugin/ExtraField/Display/CareerProfile/CareerProfileSkills.php
@@ -64,17 +64,14 @@ class CareerProfileSkills extends ExtraFieldDisplayFormattedBase {
               ->getStorage('taxonomy_term')
               ->loadByProperties(['name' => $skill['skills_competencies'], 'vid' => 'skills']);
         $term = $terms[array_key_first($terms)];
-        $icon_url = "";
         $image = "";
         if (!$term->get('field_image')->isEmpty()) {
-          $image_id = $term->field_image->entity->getFileUri();
-          $icon_url = ImageStyle::load('skill_icon')->buildUrl($image_id);
-
           $imageUri = isset($term->get('field_image')->entity) ? $term->get('field_image')->entity->getFileUri() : null;
           if($imageUri) {
             $image = [
-              '#theme' => 'image_style',
-              '#style_name' => 'skill_icon',
+              '#theme' => 'image',
+              '#width' => '75',
+              '#height' => '75',
               '#uri' => $imageUri
             ];
             $image = render($image);


### PR DESCRIPTION
While using the site I noticed that many warnings were being thrown to render the search autocomplete dropdown:
```
workbc-main-php-1       | [WARNING] [image] [2023-10-03T13:57:31] Could not apply Skill Icon image style to public://2022-12/Time management.svg because the style does not support it. | uid: 0 | request-uri: http://workbc.docker.localhost:8000/search_api_autocomplete/search_site_content?display=page_1&filter=search_api_fulltext&q=nurs | refer: http://workbc.docker.localhost:8000/ | ip:  172.20.0.1 | link:
```
This sent me down a rabbit hole of cleaning up the different warnings that occur during search indexing. 