### PR TITLE
WBCAMS-252-129 event links

### DIFF
--- a/src/config/sync/views.view.content.yml
+++ b/src/config/sync/views.view.content.yml
@@ -97,7 +97,7 @@ display:
                 add_confirmation: false
                 label_override: 'Modify content'
                 get_bundles_from_results: true
-            11:
+            9:
               action_id: workbc_draft_node_action
               preconfiguration:
                 label_override: 'Create draft'

--- a/src/config/sync/views.view.event_calendar.yml
+++ b/src/config/sync/views.view.event_calendar.yml
@@ -542,19 +542,134 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         nothing:
           id: nothing
           table: views
           field: nothing
           relationship: none
           group_type: group
-          admin_label: ''
+          admin_label: 'Global: Custom text: Grid View content'
           plugin_id: custom
           label: ''
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"list-view\">\r\n    <div class=\"row\">\r\n        <div class=\"col-md-4\">\r\n            <div class=\"sd-date-panel\">\r\n                <div class=\"sd-top\">{{ field_start_date|striptags|trim|date('F') }} </div>\r\n                <div class=\"sd-middle\">{{ field_start_date|striptags|trim|date('d') }} </div>\r\n                <div class=\"sd-bottom\">{{ field_start_date|striptags|trim|date('Y') }} </div>\r\n            </div>\r\n        </div>\r\n        <div class=\"col-md-8\">\r\n            <div class=\"right-side\">\r\n                <div class=\"e-title\">{{ title }}</div>\r\n                <div class=\"e-sub-title\">{{ field_event_type }}</div>\r\n                <div class=\"row\">\r\n                    <div class=\"col-lg-6\">\r\n                        <div class=\"ev-date\">\r\n                          <div>{% if field_start_date|striptags|trim|date('d-m-Y') == field_end_date|striptags|trim|date('d-m-Y') %}\r\n                        {{ field_start_date|striptags|trim|date('F d') }}\r\n                        {% else %}\r\n                          {{ field_start_date|striptags|trim|date('F d') }} -\r\n                          {{ field_end_date|striptags|trim|date('F d') }}\r\n                        {% endif %}</div>\r\n                          <div>{{ field_time }} </div>\r\n                        </div>\r\n                    </div>\r\n                    <div class=\"col-lg-6\">\r\n                        <div class=\"ev-address\">\r\n                            {{ field_address }} \r\n                        </div>\r\n                    </div>\r\n                </div>\r\n                <div class=\"e-description\">\r\n                    {{ body }} \r\n                </div>\r\n                <div class=\"e-ta\">\r\n                    Target Audience: {{ field_audience }} \r\n                </div>\r\n            </div>\r\n        </div>\r\n    </div>\r\n</div>\r\n<div class=\"grid-view\">\r\n  <div class=\"grid-title\">{{ title  }}</div>\r\n  <div class=\"grid-sub-title\">{{ field_event_type }}</div>\r\n</div>"
+            text: "<div id=\"event-id-{{ nid }}\" class=\"grid-view\">\r\n  <div class=\"grid-title\">{{ title  }}</div>\r\n  <div class=\"grid-sub-title\">{{ field_event_type }}</div>\r\n</div>"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+        nothing_1:
+          id: nothing_1
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: 'Global: Custom text: List View content'
+          plugin_id: custom
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: "<div id=\"event-id-{{ nid }}\" class=\"list-view \">\r\n    <div class=\"row\">\r\n        <div class=\"col-md-4\">\r\n            <div class=\"sd-date-panel\">\r\n                <div class=\"sd-top\">{{ field_start_date|striptags|trim|date('F') }} </div>\r\n                <div class=\"sd-middle\">{{ field_start_date|striptags|trim|date('d') }} </div>\r\n                <div class=\"sd-bottom\">{{ field_start_date|striptags|trim|date('Y') }} </div>\r\n            </div>\r\n        </div>\r\n        <div class=\"col-md-8\">\r\n            <div class=\"right-side\">\r\n                <div class=\"e-title\">{{ title }}</div>\r\n                <div class=\"e-sub-title\">{{ field_event_type }}</div>\r\n                <div class=\"row\">\r\n                    <div class=\"col-lg-6\">\r\n                        <div class=\"ev-date\">\r\n                          <div>{% if field_start_date|striptags|trim|date('d-m-Y') == field_end_date|striptags|trim|date('d-m-Y') %}\r\n                        {{ field_start_date|striptags|trim|date('F d') }}\r\n                        {% else %}\r\n                          {{ field_start_date|striptags|trim|date('F d') }} -\r\n                          {{ field_end_date|striptags|trim|date('F d') }}\r\n                        {% endif %}</div>\r\n                          <div>{{ field_time }} </div>\r\n                        </div>\r\n                    </div>\r\n                    <div class=\"col-lg-6\">\r\n                        <div class=\"ev-address\">\r\n                            {{ field_address }} \r\n                        </div>\r\n                    </div>\r\n                </div>\r\n                <div class=\"e-description\">\r\n                    {{ body }} \r\n                </div>\r\n                <div class=\"e-ta\">\r\n                    Target Audience: {{ field_audience }} \r\n                </div>\r\n            </div>\r\n        </div>\r\n    </div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -712,6 +827,8 @@ display:
           right_buttons: dayGridMonth
           default_view: dayGridMonth
           firstDay: '0'
+          minTime: '00:00:00'
+          maxTime: '23:59:59'
           nav_links: 1
           timeFormat: 'hh:mm a'
           allowEventOverlap: 1
@@ -721,14 +838,30 @@ display:
           languageSelector: 0
           dialogWindow: 0
           openEntityInNewTab: 0
+          dialogModal: 0
           createEventLink: 0
           eventLimit: '20'
+          slotDuration: '00:30:00'
           tax_field: ''
           vocabularies: ''
           color_bundle:
-            article: '#3a87ad'
+            bc_profile: '#3a87ad'
+            blog: '#3a87ad'
+            career_profile: '#3a87ad'
+            career_profile_introductions: '#3a87ad'
             event: '#3a87ad'
+            industry_profile: '#3a87ad'
+            industry_profile_introductions: '#3a87ad'
+            labour_market_monthly: '#3a87ad'
+            news: '#3a87ad'
             page: '#3a87ad'
+            publication: '#3a87ad'
+            region_profile: '#3a87ad'
+            region_profile_introductions: '#3a87ad'
+            related_topics_card: '#3a87ad'
+            resource: '#3a87ad'
+            success_story: '#3a87ad'
+            workbc_centre: '#3a87ad'
           rrule: ''
           duration: ''
           bundle_type: event

--- a/src/web/modules/custom/calendar_listview/js/cv-custom.js
+++ b/src/web/modules/custom/calendar_listview/js/cv-custom.js
@@ -57,21 +57,36 @@
       $(".fc-tue span").once().append("s");
       $(".fc-thu span").once().append("rs");
       $(".fc-day-grid-event").once().click(function(){
+
+        var id = $(this).find('.grid-view')[0].id.replace('event-id-', '');
+        var events = JSON.parse(settings.fullCalendarView[0].calendar_options).events;
+
         var content = '';
-        var content = $(this).find('.list-view').clone();
+        for (const key in events) {
+          if (events[key].eid == id) {
+            content = events[key].des;
+          }
+        }
+        
         $(".fc-day-grid-event").removeClass("active");
         $(this).addClass("active");
         if($(".calendar-full-view .bottom-buttons").height() > 100){
+          $('html, body').animate({ scrollTop: $(document).height() }, 250);
           $(".calendar-full-view .bottom-buttons").slideUp( "slow", function(){
             $(".calendar-full-view .bottom-buttons").html(content);
             $( ".calendar-full-view .bottom-buttons" ).slideDown( "slow");
           });
         }else{
-          $('html, body').animate({ scrollTop: $(document).height() }, 2000);
+          $('html, body').animate({ scrollTop: $(document).height() }, 250);
           $( ".calendar-full-view .bottom-buttons" ).slideUp();
-          $(".calendar-full-view .bottom-buttons").html($(this).find('.list-view').clone());
+          $(".calendar-full-view .bottom-buttons").html(content);
           $( ".calendar-full-view .bottom-buttons" ).slideDown( "slow");
         }
+
+        var element = context.querySelector(".list-view");
+        if (element != null) {            
+          element.scrollIntoView(alignToTop);
+        }        
       });
     }
   }

--- a/src/web/themes/custom/workbc/workbc.theme
+++ b/src/web/themes/custom/workbc/workbc.theme
@@ -328,3 +328,26 @@ function workbc_preprocess_block(&$vars) {
     }
   }
 }
+
+
+
+/**
+ * Implements template_preprocess_views_view_fullcalendar().
+ */
+function workbc_preprocess_views_view_fullcalendar(array &$variables) {
+// ksm($variables);
+// $options = $variables['#attached']['drupalSettings']['fullCalendarView'][0]['calendar_options'];
+// ksm($options);
+// $options = json_decode($options);
+// ksm($options);
+  if (!empty($variables['#attached']['drupalSettings']['fullCalendarView'])) {
+    $calendar = $variables['#attached']['drupalSettings']['fullCalendarView'][0];
+    $calendar_options = json_decode($calendar['calendar_options']);
+    foreach ($calendar_options->events as $key => $event) {
+      if (!empty($event->url)) {
+        $calendar_options->events[$key]->url = "";
+      }
+    } 
+    $variables['#attached']['drupalSettings']['fullCalendarView'][0]['calendar_options'] = json_encode($calendar_options);
+  }
+}

--- a/src/web/themes/custom/workbc/workbc.theme
+++ b/src/web/themes/custom/workbc/workbc.theme
@@ -328,26 +328,3 @@ function workbc_preprocess_block(&$vars) {
     }
   }
 }
-
-
-
-/**
- * Implements template_preprocess_views_view_fullcalendar().
- */
-function workbc_preprocess_views_view_fullcalendar(array &$variables) {
-// ksm($variables);
-// $options = $variables['#attached']['drupalSettings']['fullCalendarView'][0]['calendar_options'];
-// ksm($options);
-// $options = json_decode($options);
-// ksm($options);
-  if (!empty($variables['#attached']['drupalSettings']['fullCalendarView'])) {
-    $calendar = $variables['#attached']['drupalSettings']['fullCalendarView'][0];
-    $calendar_options = json_decode($calendar['calendar_options']);
-    foreach ($calendar_options->events as $key => $event) {
-      if (!empty($event->url)) {
-        $calendar_options->events[$key]->url = "";
-      }
-    } 
-    $variables['#attached']['drupalSettings']['fullCalendarView'][0]['calendar_options'] = json_encode($calendar_options);
-  }
-}


### PR DESCRIPTION
The Fullcalendar View module takes the last Views field and uses that to create a Description (des) field for each Event (I believe intended for a popup feature we are not using).  The data for each event (including node id) is available in the "Settings" variable passed by Drupal Behaviors.

I have reworked the Calendar view so that it now has two Global Text fields.  One (grid-view) containing the content displayed in the Calendar view and another (list-view) that contains the event description content displayed in below the Calendar when an event is clicked.  The list-view is the last field in the view configuration.

I've also added an div id to the grid-view  <div id="event-id-#> which is then used to target the correct event in the Settings data and an event is clicked.

As a result of splitting these two fields, event descriptions containing a link no longer results in a redirection.  Therefore, my fix is no longer needed and has been removed.

This PR also contains a fix for scrolling to the event description when an event is clicked (WBCAMS-129).