### PR TITLE
Update to webform 6.2.0

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -155,7 +155,7 @@
         "drupal/views_database_connector": "^2.0",
         "drupal/views_infinite_scroll": "^2.0",
         "drupal/viewsreference": "^1.8",
-        "drupal/webform": "^6.1",
+        "drupal/webform": "^6.2",
         "drush/drush": "^11.0",
         "frdh/mmenu-js": "^9.2.0",
         "google/charts": "45",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18e1ece4ba42b6a1ed8692f1e97a809f",
+    "content-hash": "57eca1d63b72f485ac7ebaa6e453beac",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -8198,46 +8198,47 @@
         },
         {
             "name": "drupal/webform",
-            "version": "6.1.7",
+            "version": "6.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/webform.git",
-                "reference": "6.1.7"
+                "reference": "6.2.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/webform-6.1.7.zip",
-                "reference": "6.1.7",
-                "shasum": "6eee721871ec6588fb3f3607165576ad1714a766"
+                "url": "https://ftp.drupal.org/files/projects/webform-6.2.0.zip",
+                "reference": "6.2.0",
+                "shasum": "7a8292fb86fa60c88377279769fd6f1b1fad05c2"
             },
             "require": {
-                "drupal/core": "^9.3"
+                "drupal/core": "^9.4 || ^10",
+                "php": ">=8.1"
             },
             "require-dev": {
                 "drupal/address": "1.x-dev",
                 "drupal/bootstrap": "3.x-dev",
-                "drupal/captcha": "1.x-dev",
+                "drupal/captcha": "^1 || ^2",
                 "drupal/chosen": "3.0.x-dev",
-                "drupal/clientside_validation": "3.0.x-dev",
+                "drupal/ckeditor": "1.0.x-dev",
+                "drupal/clientside_validation": "^3 || ^4",
                 "drupal/clientside_validation_jquery": "*",
                 "drupal/devel": "5.x-dev",
                 "drupal/entity": "1.x-dev",
                 "drupal/entity_print": "2.x-dev",
-                "drupal/gnode": "*",
                 "drupal/group": "1.x-dev",
+                "drupal/hal": "1 - 2",
                 "drupal/jquery_ui": "1.x-dev",
-                "drupal/jquery_ui_checkboxradio": "1.x-dev",
-                "drupal/jquery_ui_datepicker": "1.x-dev",
-                "drupal/lingotek": "4.0.x-dev",
+                "drupal/jquery_ui_checkboxradio": "2.x-dev",
+                "drupal/jquery_ui_datepicker": "2.x-dev",
                 "drupal/mailsystem": "4.x-dev",
+                "drupal/metatag": "1.x-dev",
                 "drupal/paragraphs": "1.x-dev",
                 "drupal/select2": "1.x-dev",
                 "drupal/smtp": "1.x-dev",
-                "drupal/styleguide": "1.x-dev",
+                "drupal/styleguide": "^1 || ^2",
                 "drupal/telephone_validation": "2.x-dev",
                 "drupal/token": "1.x-dev",
                 "drupal/variationcache": "1.x-dev",
-                "drupal/webform-webform_group": "*",
                 "drupal/webform_access": "*",
                 "drupal/webform_attachment": "*",
                 "drupal/webform_clientside_validation": "*",
@@ -8256,8 +8257,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "6.1.7",
-                    "datestamp": "1696976671",
+                    "version": "6.2.0",
+                    "datestamp": "1698674300",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8265,7 +8266,7 @@
                 },
                 "drush": {
                     "services": {
-                        "drush.services.yml": "^9 || ^10"
+                        "drush.services.yml": ">=9"
                     }
                 }
             },

--- a/src/config/sync/editor.editor.webform_default.yml
+++ b/src/config/sync/editor.editor.webform_default.yml
@@ -1,0 +1,47 @@
+uuid: 6bb90d71-9c66-4eb4-bad2-9c926cee1ed9
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.webform_default
+  module:
+    - ckeditor5
+format: webform_default
+editor: ckeditor5
+settings:
+  toolbar:
+    items:
+      - heading
+      - '|'
+      - bold
+      - italic
+      - subscript
+      - superscript
+      - '|'
+      - specialCharacters
+      - '|'
+      - numberedList
+      - bulletedList
+      - '|'
+      - link
+      - '|'
+      - indent
+      - outdent
+      - '|'
+      - blockQuote
+      - '|'
+      - sourceEditing
+  plugins:
+    ckeditor5_heading:
+      enabled_headings:
+        - heading2
+        - heading3
+        - heading4
+        - heading5
+        - heading6
+    ckeditor5_list:
+      reversed: true
+      startIndex: true
+    ckeditor5_sourceEditing:
+      allowed_tags: {  }
+image_upload: {  }

--- a/src/config/sync/filter.format.webform_default.yml
+++ b/src/config/sync/filter.format.webform_default.yml
@@ -1,0 +1,11 @@
+uuid: dc3774a1-8765-46ae-92db-8eba19bfa735
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+name: 'Webform (Default) - DO NOT EDIT'
+format: webform_default
+weight: 100
+filters: {  }

--- a/src/config/sync/user.role.authenticated.yml
+++ b/src/config/sync/user.role.authenticated.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.webform_default
     - media.type.audio
     - media.type.document
     - media.type.icon
@@ -12,6 +13,7 @@ dependencies:
   module:
     - contact
     - field_permissions
+    - filter
     - media
     - media_entity_download
     - paragraphs_type_permissions
@@ -104,6 +106,7 @@ permissions:
   - 'update paragraph content skills'
   - 'use search_api_autocomplete for search_career_profiles'
   - 'use search_api_autocomplete for search_site_content'
+  - 'use text format webform_default'
   - 'use views bulk edit'
   - 'view all media revisions'
   - 'view field_content'

--- a/src/config/sync/webform.settings.yml
+++ b/src/config/sync/webform.settings.yml
@@ -3,6 +3,8 @@ _core:
 langcode: en
 settings:
   default_status: open
+  default_categories: {  }
+  default_page: true
   default_page_base_path: /form
   default_ajax: false
   default_ajax_progress_type: throbber
@@ -45,6 +47,7 @@ settings:
   default_draft_pending_multiple_message: 'You have pending drafts for this webform. <a href="#">View your pending drafts</a>.'
   default_confirmation_message: 'New submission added to [webform:title].'
   default_confirmation_back_label: 'Back to form'
+  default_confirmation_noindex: true
   default_limit_total_message: 'No more submissions are permitted.'
   default_limit_user_message: 'No more submissions are permitted.'
   default_submission_label: '[webform_submission:submitted-to]: Submission #[webform_submission:serial]'
@@ -153,15 +156,13 @@ element:
   default_empty_option: true
   default_empty_option_required: ''
   default_empty_option_optional: ''
-  default_algolia_places_app_id: ''
-  default_algolia_places_api_key: ''
   excluded_elements:
     password: password
     password_confirm: password_confirm
 html_editor:
   disabled: false
-  element_format: ''
-  mail_format: ''
+  element_format: webform_default
+  mail_format: webform_default
   tidy: true
   make_unused_managed_files_temporary: true
 file:

--- a/src/config/sync/webform.webform.contact.yml
+++ b/src/config/sync/webform.webform.contact.yml
@@ -24,7 +24,7 @@ elements: |-
       <h2>Email</h2>
 
       <p>All fields are mandatory unless otherwise noted.</p>
-    '#format': basic_html
+    '#format': full_html
   inquiry_type:
     '#type': select
     '#title': 'Inquiry Type'

--- a/src/config/sync/webform.webform.contact.yml
+++ b/src/config/sync/webform.webform.contact.yml
@@ -16,7 +16,7 @@ archive: false
 id: contact
 title: 'Contact Us'
 description: 'Basic email contact webform.'
-category: ''
+categories: {  }
 elements: |-
   form_heading:
     '#type': processed_text
@@ -149,6 +149,8 @@ settings:
   wizard_toggle: false
   wizard_toggle_show_label: ''
   wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
   preview: 0
   preview_label: ''
   preview_title: ''

--- a/src/config/sync/webform.webform.funding_questionnaire.yml
+++ b/src/config/sync/webform.webform.funding_questionnaire.yml
@@ -11,7 +11,7 @@ archive: false
 id: funding_questionnaire
 title: 'Funding Questionnaire'
 description: 'Also called Self-Assessment Questionnaire.'
-category: ''
+categories: {  }
 elements: |-
   intro:
     '#type': webform_wizard_page
@@ -271,6 +271,8 @@ settings:
   wizard_toggle: false
   wizard_toggle_show_label: ''
   wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
   preview: 0
   preview_label: ''
   preview_title: ''

--- a/src/config/sync/webform.webform.request_a_tour_stop.yml
+++ b/src/config/sync/webform.webform.request_a_tour_stop.yml
@@ -11,7 +11,7 @@ archive: false
 id: request_a_tour_stop
 title: 'Request a Tour Stop'
 description: 'Webform to collect Request a Tour Stop&nbsp; information'
-category: ''
+categories: {  }
 elements: |-
   introduction_text:
     '#type': processed_text
@@ -193,6 +193,8 @@ settings:
   wizard_toggle: true
   wizard_toggle_show_label: ''
   wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
   preview: 0
   preview_label: ''
   preview_title: ''

--- a/src/config/sync/webform.webform.request_a_tour_stop.yml
+++ b/src/config/sync/webform.webform.request_a_tour_stop.yml
@@ -17,7 +17,7 @@ elements: |-
     '#type': processed_text
     '#text': |
       <p>Interested in having a Find Your Fit tour stop in your community? Submit your request here.</p>
-    '#format': basic_html
+    '#format': full_html
   name:
     '#type': textfield
     '#title': Name

--- a/src/config/sync/webform.webform.workbc_order_form.yml
+++ b/src/config/sync/webform.webform.workbc_order_form.yml
@@ -13,7 +13,7 @@ archive: false
 id: workbc_order_form
 title: 'WorkBC Resource Order Form'
 description: 'Webform for ordering WorkBC publications.'
-category: ''
+categories: {  }
 elements: |-
   workbc_order_form_intro:
     '#type': webform_markup
@@ -158,6 +158,8 @@ settings:
   wizard_toggle: true
   wizard_toggle_show_label: ''
   wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
   preview: 0
   preview_label: ''
   preview_title: ''


### PR DESCRIPTION
Upgrade to Webform 6.2.0

NOTE:  The two instances where the filter format is changed to "Full HTML" are information fields for display on the forms, they are not fields the general public has access too.

I've included screen shots of the two fields in case they trigger a memory that there are tickets that supersede the wireframes.
 
![webform620-Contact-Us-WorkBC](https://github.com/bcgov/workbc-main/assets/1471584/73579d29-5ed2-425a-86f1-263bcf3e110e)
![webform620-Request-a-Tour-Stop-WorkBC](https://github.com/bcgov/workbc-main/assets/1471584/9fd6bdad-0e51-4c91-b880-9334074c3948)
