### PR TITLE
[WBCAMS-206] Fix calendar caching

### DIFF
--- a/src/web/modules/custom/calendar_listview/calendar_listview.module
+++ b/src/web/modules/custom/calendar_listview/calendar_listview.module
@@ -70,7 +70,7 @@ function calendar_listview_theme_suggestions_page_alter(array &$suggestions, arr
 }
 
 function calendar_listview_preprocess_node(&$variables) {
-  $nid = $variables['node']->id();
+  $variables['#cache']['max-age'] = 0;
   $mode = \Drupal::request()->query->get('mode');
   $mode = (!empty($mode))? $mode : "calendar";
   $variables['viewmode'] = $mode;


### PR DESCRIPTION
I found a regression whereby the calendar page was being cached - in this case incorrectly, because the List vs. Calendar view of that page relies on a URL query argument. This PR disables the cache for this page.
