### PR TITLE
WBCAMS-455 disable media entity dlcke module

### DIFF
--- a/src/config/sync/core.extension.yml
+++ b/src/config/sync/core.extension.yml
@@ -84,7 +84,6 @@ module:
   log_stdout: 0
   mail_login: 0
   media: 0
-  media_entity_dlcke: 0
   media_entity_download: 0
   media_file_delete: 0
   media_library: 0

--- a/src/config/sync/filter.format.full_html.yml
+++ b/src/config/sync/filter.format.full_html.yml
@@ -10,7 +10,6 @@ dependencies:
     - editor
     - linkit
     - media
-    - media_entity_dlcke
     - workbc_custom
 _core:
   default_config_hash: WNeK5FbcY8pXgEpbD_KgRzlF1-5PL3BJXwqaBctPTqw
@@ -107,12 +106,6 @@ filters:
     provider: ckeditor_media_resize
     status: true
     weight: -43
-    settings: {  }
-  media_entity_dlcke_filter:
-    id: media_entity_dlcke_filter
-    provider: media_entity_dlcke
-    status: false
-    weight: -36
     settings: {  }
   filter_allow_all:
     id: filter_allow_all


### PR DESCRIPTION
media_entity_dlcke is no longer needed as it was replaced with CKEditor 5 Media Download Link module.