### PR TITLE
WBCAMS-600 hoo wage filter

### DIFF
--- a/src/config/sync/views.view.high_opportunity_occupations.yml
+++ b/src/config/sync/views.view.high_opportunity_occupations.yml
@@ -856,10 +856,10 @@ display:
                   value: ''
               5:
                 title: '$50.00+ per hour'
-                operator: '>='
+                operator: between
                 value:
-                  min: ''
-                  max: ''
+                  min: '50'
+                  max: '2500'
                   value: '50'
       filter_groups:
         operator: AND


### PR DESCRIPTION
I looked into doing some custom filtering but it didn't look feasible and simply setting hourly wage for $50+ option to 2500 accomplishes the task based on the assumption no hourly rate will be as high as $2,500/hour or any salary as low as $2,500/year