### PR TITLE
[WBCAMS-1998] resolve quick reads duplicate card issue

### DIFF
--- a/src/config/sync/views.view.quick_reads.yml
+++ b/src/config/sync/views.view.quick_reads.yml
@@ -492,6 +492,21 @@ display:
             field_identifier: ''
           exposed: false
           granularity: second
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: 'ID (required to ensure uniqueness for correct pagination)'
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments: {  }
       filters:
         status:


### PR DESCRIPTION
This issue is the result of multiple Success Stories with the same Published date and PostgreSQL LIMIT and OFFSET not guaranteeing any default order without unique sort by values.  The problem is solved by adding Node ID to View Sort criteria.

I added a note to the field label to make clear using the ID as part of the Sort does serve a purpose.