### PR TITLE
[WBCAMS-2015] update global search field accessibility label, config update

### DIFF
--- a/src/config/sync/core.extension.yml
+++ b/src/config/sync/core.extension.yml
@@ -72,6 +72,7 @@ module:
   jquery_ui_accordion: 0
   jquery_ui_autocomplete: 0
   jquery_ui_menu: 0
+  js_cookie: 0
   key: 0
   keycloak: 0
   language: 0

--- a/src/web/themes/custom/workbc/workbc.theme
+++ b/src/web/themes/custom/workbc/workbc.theme
@@ -225,7 +225,7 @@ function workbc_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_st
       'views-exposed-form-search-site-content-block-1'
   ])) {
     $form['#attributes']['class'][] = 'search-form';
-    $form['search_api_fulltext']['#attributes']['aria-label'] = 'Search';
+    $form['search_api_fulltext']['#attributes']['aria-label'] = 'Search WorkBC.ca';
   }
   if ($form_id === 'views_exposed_form' && $form['#id'] === 'views-exposed-form-search-site-content-page-1') {
     $form['sort_by']['#weight'] = 100;


### PR DESCRIPTION
The "missing form label" error referred to in the ticket are not for this field (they are for hidden fields related to Google Translate).  There already was a label which I've updated to match expected behaviour.

This update also includes a configuration update.  The latest update to the Fast Permissions Administration (FPA) module now requires the JS Cookie module which is installed when the FPA module is updated.  I've updated the `core.extension.yml` to include the new enabled JS Cookie module.