### PR TITLE
Fix master CI: reroll backup_migrate patch for 5.1.5 (cherry-pick from ams)

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -251,7 +251,7 @@
             },
             "drupal/backup_migrate": {
                 "PostgreSQL support": "patches/drupal/backup_migrate/0003-postgresql-support.patch",
-                "Directory restore": "patches/drupal/backup_migrate/backup-migrate-restore-public-files-3245802-3.patch"
+                "Directory restore": "patches/drupal/backup_migrate/backup-migrate-restore-public-files-3245802-4.patch"
             },
             "drupal/redirect": {
                 "Ignore query strings": "patches/drupal/redirect/2976930-redirect-hashes-created-when-not-retaining-the-query-string-2.patch",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cfdd575333731177593af56146123d34",
+    "content-hash": "600fa3e42cfa73c51ee7f63edf9791d3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2072,20 +2072,20 @@
         },
         {
             "name": "drupal/backup_migrate",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/backup_migrate.git",
-                "reference": "5.1.4"
+                "reference": "5.1.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/backup_migrate-5.1.4.zip",
-                "reference": "5.1.4",
-                "shasum": "4d2c90e89bb376f07aea23bcfb5d9467ffb7d09c"
+                "url": "https://ftp.drupal.org/files/projects/backup_migrate-5.1.5.zip",
+                "reference": "5.1.5",
+                "shasum": "151f628107dd89441ab0ea351c25b759c058f8c4"
             },
             "require": {
-                "drupal/core": "^9.5 || ^10 || ^11"
+                "drupal/core": "^10.3 || ^11"
             },
             "suggest": {
                 "defuse/php-encryption": "Optional encryption of saved backups."
@@ -2093,8 +2093,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "5.1.4",
-                    "datestamp": "1771081280",
+                    "version": "5.1.5",
+                    "datestamp": "1783803200",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -20536,6 +20536,6 @@
     "platform": {
         "php": ">=8.3"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/src/patches/drupal/backup_migrate/backup-migrate-restore-public-files-3245802-4.patch
+++ b/src/patches/drupal/backup_migrate/backup-migrate-restore-public-files-3245802-4.patch
@@ -3,7 +3,7 @@ index e4e522a..03823ae 100644
 --- a/src/Core/Service/TarArchiveReader.php
 +++ b/src/Core/Service/TarArchiveReader.php
 @@ -137,7 +137,7 @@ class TarArchiveReader implements ArchiveReaderInterface {
- 
+
        // Extract a directory.
        if ($header['typeflag'] == "5") {
 -        if (!$this->createDir($header['filename'])) {
@@ -16,7 +16,7 @@ index e4e522a..03823ae 100644
        // Extract a file/symlink.
        else {
 -        if (!$this->createDir(dirname($header['filename']))) {
-+        if (!$this->createDir($directory, dirname($filename)))) {
++        if (!$this->createDir($directory, dirname($filename))) {
            throw new BackupMigrateException(
              'Unable to create directory for %filename',
              ['%filename' => $header['filename']]
@@ -38,7 +38,7 @@ index e4e522a..03823ae 100644
      }
 -    $parent = dirname($directory);
 +    $parent = dirname($filename);
- 
+
      if (
 -      ($parent != $directory) &&
 +      ($parent != $filename) &&

--- a/src/patches/drupal/backup_migrate/backup-migrate-restore-public-files-3245802-4.patch
+++ b/src/patches/drupal/backup_migrate/backup-migrate-restore-public-files-3245802-4.patch
@@ -1,16 +1,8 @@
 diff --git a/src/Core/Service/TarArchiveReader.php b/src/Core/Service/TarArchiveReader.php
-index bf1b9d6..0077483 100644
+index e4e522a..03823ae 100644
 --- a/src/Core/Service/TarArchiveReader.php
 +++ b/src/Core/Service/TarArchiveReader.php
-@@ -90,6 +90,7 @@ class TarArchiveReader implements ArchiveReaderInterface {
-       }
- 
-       // Add the destination directory to the path.
-+      $filename = $header['filename'];
-       if (substr($header['filename'], 0, 1) == '/') {
-         $header['filename'] = $directory . $header['filename'];
-       }
-@@ -128,7 +129,7 @@ class TarArchiveReader implements ArchiveReaderInterface {
+@@ -137,7 +137,7 @@ class TarArchiveReader implements ArchiveReaderInterface {
  
        // Extract a directory.
        if ($header['typeflag'] == "5") {
@@ -19,22 +11,24 @@ index bf1b9d6..0077483 100644
            throw new BackupMigrateException(
              'Unable to create directory %filename',
              ['%filename' => $header['filename']]
-@@ -137,7 +138,7 @@ class TarArchiveReader implements ArchiveReaderInterface {
+@@ -146,7 +146,7 @@ class TarArchiveReader implements ArchiveReaderInterface {
        }
        // Extract a file/symlink.
        else {
 -        if (!$this->createDir(dirname($header['filename']))) {
-+        if (!$this->createDir($directory, dirname($filename))) {
++        if (!$this->createDir($directory, dirname($filename)))) {
            throw new BackupMigrateException(
              'Unable to create directory for %filename',
              ['%filename' => $header['filename']]
-@@ -220,23 +221,24 @@ class TarArchiveReader implements ArchiveReaderInterface {
-    * Create a directory or return true if it already exists.
+@@ -231,23 +231,26 @@ class TarArchiveReader implements ArchiveReaderInterface {
+    * @param mixed $directory
+    *   The directory.
     *
-    * @param $directory
-+   * @param $filename
-    *
++   * @param mixed $filename
++   *   The filename.
++   *
     * @return bool
+    *   TRUE when successful, FALSE otherwise.
     */
 -  private function createDir($directory) {
 -    if ((@is_dir($directory)) || ($directory == '')) {


### PR DESCRIPTION
Fixes the TEST-CI Docker-build failure on `master` (seen on the #884 merge push):

```
Cannot apply patch Directory restore (patches/drupal/backup_migrate/backup-migrate-restore-public-files-3245802-3.patch)!
```

The Dockerfile runs `composer install && composer update`; `composer update` now resolves `drupal/backup_migrate` to **5.1.5**, where the old `-3` patch no longer applies. This is a pre-existing error unrelated to any specific commit every fresh master build fails.

`ams` already hit and fixed this on 2026-07-13 (infojunkie's `093b2c53` + `9d077e2e`). This PR cherry-picks both commits onto master (`-x` annotated, original authorship kept):

- reroll the patch to `backup-migrate-restore-public-files-3245802-4.patch` (final content byte-identical to ams) and point `composer.json` at it
- `composer.lock`: master's lock kept, with only the `drupal/backup_migrate` entry bumped 5.1.4 → 5.1.5 (so `composer install` applies the `-4` patch against the version it was rerolled for) and `content-hash` recomputed via Composer's own `Locker::getContentHash` (method verified by reproducing master's previous hash). ams' unrelated lock drift (aws-sdk, drush, guzzle…) and ams-only requirements (`drupal/sitemap`) were deliberately **not** brought over.