### PR TITLE
Embed the Laravel job board search via iframe (ADR-006)

### DIFF
--- a/src/web/modules/custom/workbc_jobboard/js/workbc_jobboard.js
+++ b/src/web/modules/custom/workbc_jobboard/js/workbc_jobboard.js
@@ -8,6 +8,31 @@
         window.addEventListener('dialog:aftercreate', navUserMenu);
       });
 
+      // ADR-006 — content-height bridge for the framed job board.
+      //
+      // A cross-origin iframe cannot size itself to its content, so without this
+      // the frame stays a fixed box and scrolls internally: the search form
+      // scrolls out of view while the Drupal chrome around it sits still. The
+      // framed app posts its document height on load, on resize and after every
+      // Livewire update; mirroring that onto the element makes the PAGE scroll
+      // and the frame simply grow.
+      once('jobBoardEmbed', '#jobboard-search', context).forEach(function (frame) {
+        // Derive the trusted origin from the iframe's own src rather than
+        // hardcoding it, so dev/test/prod need no per-environment edit.
+        var appOrigin = new URL(frame.getAttribute('src'), window.location.href).origin;
+
+        window.addEventListener('message', function (e) {
+          // Any site can postMessage to this window, so check the sender.
+          if (e.origin !== appOrigin) { return; }
+          if (!e.data || e.data.type !== 'jobboard:height') { return; }
+
+          var height = parseInt(e.data.height, 10);
+          if (!isFinite(height) || height <= 0) { return; }
+
+          frame.style.height = height + 'px';
+        });
+      });
+
       once('jobBoard', 'body.account', context).forEach(function() {
         window.addEventListener('load', accountPageChanges);
         window.addEventListener('hashchange', accountPageChanges);

--- a/src/web/modules/custom/workbc_jobboard/templates/node-page-jobboard-findjobs.html.twig
+++ b/src/web/modules/custom/workbc_jobboard/templates/node-page-jobboard-findjobs.html.twig
@@ -141,16 +141,32 @@
     {% if jobboard_connection %}
       {{ jobboard_connection }}
     {% else %}
-      <link rel="stylesheet" href="{{jobboard_api_url_frontend}}/bootstrap/bootstrap.min.css?v={{drupal_config('jobboard', 'sha')}}">
-      <link rel="stylesheet" href="{{jobboard_api_url_frontend}}/dist/jb-search/styles.css?v={{drupal_config('jobboard', 'sha')}}">
-      <app-root api="{{jobboard_api_url_frontend}}/" jbsearch="{{find_job_url}}" jbaccount="{{find_job_account_url}}" _nghost-dxq-c45="" ng-version="12.2.16"></app-root>
-      <script src="{{jobboard_api_url_frontend}}/dist/jb-search/runtime-es2017.js?v={{drupal_config('jobboard', 'sha')}}" type="module"></script>
-      <script src="{{jobboard_api_url_frontend}}/dist/jb-search/runtime-es5.js?v={{drupal_config('jobboard', 'sha')}}" nomodule="" defer=""></script>
-      <script src="{{jobboard_api_url_frontend}}/dist/jb-search/polyfills-es2017.js?v={{drupal_config('jobboard', 'sha')}}" type="module"></script>
-      <script src="{{jobboard_api_url_frontend}}/dist/jb-search/polyfills-es5.js?v={{drupal_config('jobboard', 'sha')}}" nomodule="" defer=""></script>
-      <script src="{{jobboard_api_url_frontend}}/dist/jb-search/main-es2017.js?v={{drupal_config('jobboard', 'sha')}}" type="module"></script>
-      <script src="{{jobboard_api_url_frontend}}/dist/jb-search/main-es5.js?v={{drupal_config('jobboard', 'sha')}}" nomodule="" defer=""></script>
-      <script src="https://maps.googleapis.com/maps/api/js?key={{google_maps_key}}" async defer=""></script>
+      {#
+        ADR-006 — the search UI is FRAMED, not injected.
+
+        The Laravel rewrite renders server-side HTML bound to its own session and
+        CSRF token, so it cannot be shipped as a bundle dropped into this
+        document's DOM the way the Angular build was. The whole inline-injection
+        pattern ends here: no stylesheets, no <app-root>, no six-bundle script
+        list, and no Google Maps tag (the app loads its own key inside the frame
+        — Drupal's `google_maps_key` cannot reach across the origin boundary).
+
+        `jobboard_api_url_frontend` is reused deliberately rather than hardcoding
+        a hostname: it already resolves per-environment, so test and prod need no
+        further edit when they are repointed.
+
+        `?embed=1` selects the chrome-less layout (FND-4) — Drupal keeps the
+        hero, breadcrumbs, sidebar and social sharing above.
+
+        Height is driven by the `jobboard:height` listener in
+        js/workbc_jobboard.js, which replaces min-height once the frame reports
+        its content height. Without that JS the frame stays 60vh and scrolls
+        internally, which hides the search form as you scroll the results.
+      #}
+      <iframe id="jobboard-search"
+              src="{{jobboard_api_url_frontend}}/jobs?embed=1"
+              title="Search jobs in B.C."
+              style="width:100%;border:0;min-height:60vh"></iframe>
     {% endif %}
     </div>
 


### PR DESCRIPTION
Swaps the Find Jobs page from inline-injected Angular bundles to an iframe pointing at the Laravel rewrite, plus a postMessage height listener so the frame sizes to its content. Tested on dev2. Note: the app is currently on a Stratus hostname that is cross-site with dev2.workbc.ca, so session cookies need SameSite=None/Partitioned on the app side until it gets a workbc.ca hostname.